### PR TITLE
removed line separators

### DIFF
--- a/Extended Structured Binding.md
+++ b/Extended Structured Binding.md
@@ -6,13 +6,9 @@
 - **Audience:** Evolution Working Group (EWG)
 - **Authors:** Yehonatan Simian, ... (add your names here)
 
-----------
-
 ### Abstract
 
 This proposal introduces an extension to C++'s structured bindings, allowing for the assignment of values to existing variables. This provides a clean, consistent syntax that serves as a modern alternative to `std::tie`, particularly for environments where the standard library is unavailable, such as in embedded or bare-metal development.
-
-----------
 
 ### Introduction
 
@@ -38,8 +34,6 @@ While effective, `std::tie` is not a language-level feature. Its use presents tw
     
 
 This proposal aims to address these issues by extending structured binding syntax to support assignment to existing variables.
-
-----------
 
 ### Proposal
 
@@ -101,8 +95,6 @@ auto [&age, height] = get_info(); // `age` is assigned, `height` is declared.
 // Height height = std::get<1>(get_info());
 ```
 
-----------
-
 ### Motivation and Use Cases
 
 #### 1. Embedded and Bare-Metal Systems
@@ -113,8 +105,6 @@ The most compelling technical motivation for this proposal is its applicability 
 
 Structured bindings are a well-loved feature for their intuitive nature. `std::tie` requires a separate header, a different syntax, and introduces a new concept (a function that returns a `tuple` of references) to solve a common problem. The proposed syntax leverages an existing, familiar pattern, reducing cognitive overhead and making code more consistent and easier to understand for newcomers and seasoned developers alike.
 
-
-----------
 
 ### Alternative Syntaxes Considered
 
@@ -135,13 +125,9 @@ let [&x, y] = get_values();
 More robust, yet has a potential of ambiguity with Pattern Matching.
 
 
-----------
-
 ### Implementation Notes
 
 This is a language extension, not a standard library addition. A compiler would need to implement this new parsing rule. The implementation would involve checking the variables in the `binding-list` against the variables in the current scope. If an existing variable is found with the `assigns` keyword, the compiler would generate code to perform an assignment using the variable's `operator=`. If `auto` is used, a new variable would be declared.
-
-----------
 
 ### Previous Papers
 
@@ -150,8 +136,6 @@ This is a language extension, not a standard library addition. A compiler would 
     
 -   **P2392 - `C++ Standard Library Support for Structured Bindings`**: While not directly related to this proposal, Herb Sutter's paper and similar documents highlight the evolution of structured bindings and the community's interest in extending their utility.
     
-
-----------
 
 ### Conclusion
 


### PR DESCRIPTION
The line separators does not help with readability and
they are uncommon in WG21 papers.
