### PR TITLE
Address CV-Qualifiers

### DIFF
--- a/P3817.md
+++ b/P3817.md
@@ -72,6 +72,32 @@ The `&` symbol already signifies a reference in C++. By allowing it inside the s
 
 When an existing variable is prefixed with `&`, the compiler would find the variable in the current scope and assign the corresponding element of the tuple-like object to it using `operator=`. The `auto` keyword at the beginning of the statement would signal that this is a structured binding operation.
 
+### CV-Qualifiers and Variable Properties
+
+This proposal naturally extends to support cv-qualifiers (`const`, `volatile`) within the structured binding list, providing enhanced flexibility for variable declarations.
+The design follows a clear conceptual framework: qualifiers outside the square brackets (e.g., `const auto &[x,y]`) relate to how the tuple itself is accessed, while qualifiers inside the brackets (e.g., `auto [const x, &y]`) specify properties of individual bindings.
+This allows developers to write `auto [const x, volatile y, &existing_var] = get_tuple();` where new variables can be declared with specific cv-qualifications while existing variables are assigned through the `&` prefix.
+
+Importantly, this approach maintains logical consistency by disallowing meaningless combinations: existing variables referenced with `&` cannot have additional cv-qualifiers applied (since their constness is already determined), and outer const qualifiers are incompatible with assignment to existing variables.
+This extension would provide significant value even if regular structured bindings don't yet support cv-qualifiers, as it offers a more complete and flexible binding mechanism that anticipates future language evolution.
+
+```cpp
+// VALID - inner qualifiers for new variables
+auto [const x, volatile y] = get_pair();
+
+// VALID - mixing new (with qualifiers) and existing
+auto [const x, &existing_var] = get_pair();
+
+// INVALID - can't make existing variable const through binding
+auto [&existing_const_var] = get_tuple();
+
+// INVALID - outer const conflicts with assignment to existing vars
+const auto [&x, y] = get_pair(); // doesn't make sense
+```
+
+Note: this approach also addresses the granularity issues that led to the deprecation of `volatile` in structured binding declarations in C++20 ([P1152R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1152r4.html)).
+The deprecation of `volatile auto [x, y] = get_pair()` highlighted the semantic confusion of applying cv-qualifiers to the entire decomposition mechanism rather than to individual variables. Our proposal's syntax `auto [volatile x, const y] = get_pair()` provides the precise, per-variable control that the deprecation implicitly identified as the preferred approach, offering a more semantically correct alternative that applies qualifiers exactly where they're needed.
+
 ## Examples
 
 ### 1. Assigning to Existing Variables Only
@@ -305,3 +331,4 @@ The working group is encouraged to discuss this proposal and provide feedback on
 ## References
 
 - [P0144R2 - Structured Bindings](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0144r2.pdf)
+- [P1152R4 - Deprecating `volatile`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1152r4.html)


### PR DESCRIPTION
This is an interesting topic, especially since `volatile` get more and more deprecated as time goes; however, the way I see it, the reason for most `volatile` deprecations is that its behavior is often misunderstood and can lead to subtle, hard-to-diagnose bugs. More specifically, it is generally recommended to apply volatile to the individual member type within the underlying aggregate or tuple-like type; in other words, and quite ironically, our proposal is *strongly supported* by the `volatile` deprecation for allowing precise, per-variable control.

Sources:
- [P1152R4 - Deprecating `volatile`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1152r4.html) (mentioned in this PR).
- [P2866R2 - Remove Deprecated Volatile Features from C++26](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2866r2.pdf) (not mentioned in the current PR, but includes some insights about the `volatile` deprecation).