### PR TITLE
removed 'fixme' comment

### DIFF
--- a/P3817.md
+++ b/P3817.md
@@ -19,8 +19,6 @@ This proposal introduces an extension to C++'s structured bindings, allowing for
 
 ## Motivation
 
-This section is pending on <https://github.com/yonisimian/cpp-proposals/issues/5>
-
 Allowing assignment for existing variables provides the following benefits:
 
 1. It is particularly useful for environments where the standard library is unavailable, such as in embedded or bare-metal development.


### PR DESCRIPTION
as agreed in 2025-08-31 meeting, the md should be clear from a `fixme` like comments, thus removing the one I added in the past.
