### PR TITLE
suggested const behaviour

### DIFF
--- a/P3817.md
+++ b/P3817.md
@@ -342,8 +342,21 @@ int& y = __e_p3817.y;
 Ill-Formed for Assigned Elements
 
 ```cpp
-const auto [using x, y] = ar;  // ill-formed: cannot assign in a const binding
+const auto [using p, q] = arr;  // ill-formed: cannot use const with using-marked elements
 ```
+
+**Alternative Considered**
+
+Under this alternative, `const` appertains to the hidden variable _e_ — not to the `using`-marked targets — and the declaration is valid. However, this raises a question that defies easy resolution: given
+
+```cpp
+Point p, q;
+const auto [using p, using q] = get_pair();
+```
+
+`p` and `q` are already-declared variables with well-known types. Does this declaration change their types? If yes, that is contrary to C++ semantics — a declaration cannot retroactively change the type of an existing variable. If no, then `const` has no observable effect on the `using`-marked elements, which is misleading.
+
+In practice, `const` would only make _e_ const, causing assignments to copy rather than move — a subtle effect invisible in the source. The authors therefore prefer the ill-formed approach.
 
 #### Returned Lvalues
 


### PR DESCRIPTION

```cpp
const auto& [using t, y] = foo(); 
```

is not ill formed. we can assign to t;
the new declared variable y gets the constness, t does not.
See details in the paper.

