### PR TITLE
immidiate move implication

### DIFF
--- a/P3817.md
+++ b/P3817.md
@@ -333,7 +333,7 @@ int& y = __e_p3817.y;
 
 > <sup>†</sup> [[dcl.struct.bind] ¶8](https://eel.is/c++draft/dcl.struct.bind) imposes no aggregate requirement: any class type with publicly accessible direct members and no `std::tuple_size` specialization reaches this case, including non-aggregates with user-provided constructors.
 
-**Immediate-move implication.** For `auto [using x, ...]`, the move assignment to `x` happens at the binding statement, not deferred to the point of use. For types whose `operator=(T&&)` has observable side effects, this is a behavioral difference from the `std::tie` / `auto [e1, ...]` pattern, where the move is explicit and deferred.
+**Immediate-move implication.** For `auto [using x, ...]`, the move assignment to `x` happens at the binding statement.
 
 ### Further Design Decisions
 


### PR DESCRIPTION

Closes: #58

The sentence suggesting a comparison between std::tie
or something along the lines of: auto [e, z] = f() ... x = std:move(e)
was misleading - there is nothing to compare and therefore
there is no need in code example.
The sentence was shorten to its bare minimum - just pointing
the fact that move happens at declaration time.
